### PR TITLE
docs: Update installer URLs to v1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,24 +20,24 @@ Stop wasting time explaining your environment setup to Cursor in every conversat
 
 **macOS/Linux:**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/v1.0.0/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/v1.0.1/install.sh | bash
 ```
 
 **Windows (PowerShell):**
 ```powershell
-irm https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/v1.0.0/install.ps1 | iex
+irm https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/v1.0.1/install.ps1 | iex
 ```
 
-> **Security Note:** The installer downloads and runs scripts from GitHub. You can [review the installer script](https://github.com/u00dxk2/cursor-kooi-env-docs/blob/v1.0.0/install.sh) before running. It only creates a `.cursor/` directory in your current project—no system-level changes, no admin/root privileges required.
+> **Security Note:** The installer downloads and runs scripts from GitHub. You can [review the installer script](https://github.com/u00dxk2/cursor-kooi-env-docs/blob/v1.0.1/install.sh) before running. It only creates a `.cursor/` directory in your current project—no system-level changes, no admin/root privileges required.
 
 > **⚠️ Existing .cursor/ Setup:** The installer **preserves existing files** by default. If you have an existing `.cursor/` directory, only missing files will be added. To overwrite everything (clean reinstall), download the installer and run with `--force` flag:
 > ```bash
 > # Unix/Mac
-> curl -fsSL https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/v1.0.0/install.sh -o install.sh
+> curl -fsSL https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/v1.0.1/install.sh -o install.sh
 > bash install.sh --force
 > 
 > # Windows
-> irm https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/v1.0.0/install.ps1 -OutFile install.ps1
+> irm https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/v1.0.1/install.ps1 -OutFile install.ps1
 > .\install.ps1 --force
 > ```
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -65,12 +65,12 @@ Cursor has built-in support for reading the `.cursor/` directory and applying ru
 
 macOS/Linux:
 ```bash
-curl -fsSL https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/v1.0.0/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/v1.0.1/install.sh | bash
 ```
 
 Windows PowerShell:
 ```powershell
-irm https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/v1.0.0/install.ps1 | iex
+irm https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/v1.0.1/install.ps1 | iex
 ```
 
 **Manual install:**
@@ -184,13 +184,13 @@ Existing files will be preserved (use --force to overwrite)
 **Need a clean reinstall?** Use the `--force` flag:
 ```bash
 # Download installer first
-curl -fsSL https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/v1.0.0/install.sh -o install.sh
+curl -fsSL https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/v1.0.1/install.sh -o install.sh
 
 # Run with --force to overwrite everything
 bash install.sh --force
 
 # Or PowerShell:
-irm https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/v1.0.0/install.ps1 -OutFile install.ps1
+irm https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/v1.0.1/install.ps1 -OutFile install.ps1
 .\install.ps1 --force
 ```
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -36,7 +36,7 @@ sudo yum install curl          # RHEL/CentOS
 brew install curl              # macOS
 
 # Or use wget instead
-wget -O- https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/v1.0.0/install.sh | bash
+wget -O- https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/v1.0.1/install.sh | bash
 ```
 
 **For Windows (not PowerShell):**
@@ -57,7 +57,7 @@ wget -O- https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/v1.0.0/i
 
 **Example:**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/v1.0.0/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/v1.0.1/install.sh | bash
 
 # Output:
 ⚠️  Existing .cursor/ setup detected
@@ -82,11 +82,11 @@ Existing files will be preserved (use --force to overwrite)
 **How to use --force:**
 ```bash
 # Unix/Mac
-curl -fsSL https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/v1.0.0/install.sh -o install.sh
+curl -fsSL https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/v1.0.1/install.sh -o install.sh
 bash install.sh --force
 
 # Windows
-irm https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/v1.0.0/install.ps1 -OutFile install.ps1
+irm https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/v1.0.1/install.ps1 -OutFile install.ps1
 .\install.ps1 --force
 ```
 


### PR DESCRIPTION
## 📦 Update Version References

Updates all installer URLs from v1.0.0 to v1.0.1 to point users to the latest stable release.

### 📝 Changes

Updated **13 version references** across 3 files:

#### README.md (5 references)
- Quick Start installer URLs (2)
- Force flag example URLs (2)
- Security note link (1)

#### docs/FAQ.md (4 references)
- Installation section URLs (2)
- Force reinstall example URLs (2)

#### docs/TROUBLESHOOTING.md (4 references)
- wget alternative URL (1)
- Existing .cursor/ example URL (1)
- Force flag example URLs (2)

### ✅ Impact

- Users now get the latest bug fixes (installer messaging + git guidance)
- URLs point to stable tagged release instead of v1.0.0
- All documentation is consistent with current release

### 🎯 Related

- Follows release of v1.0.1 (just published)
- Ensures documentation accuracy