### PR TITLE
fix: PS5.1-safe installers and validators

### DIFF
--- a/.cursor/check-env-docs.ps1
+++ b/.cursor/check-env-docs.ps1
@@ -1,7 +1,8 @@
 # Check Environment Documentation Staleness
-# Run this script to see if .cursor/project-environment.md needs review
+# Run this script to see if .cursor/rules/project-environment.mdc needs review
 
-$envDocPath = ".cursor/project-environment.md"
+$cursorDir = $PSScriptRoot
+$envDocPath = Join-Path $cursorDir "rules\\project-environment.mdc"
 $warningDays = 7
 $criticalDays = 14
 

--- a/.cursor/rules/project-environment.mdc
+++ b/.cursor/rules/project-environment.mdc
@@ -6,9 +6,9 @@ alwaysApply: true
 
 # Project Environment Documentation
 
-> **Last Updated:** 2025-10-10  
+> **Last Updated:** 2026-01-04  
 > **Review Frequency:** Check every conversation, update when environment changes  
-> **Next Review:** 2025-10-17
+> **Next Review:** 2026-01-11
 
 ## 📋 Maintenance Log
 
@@ -17,6 +17,7 @@ alwaysApply: true
 | 2025-10-04 | Initial documentation for cursor-kooi-env-docs repository | AI Assistant |
 | 2025-10-08 | Converted to .mdc format for automatic ingestion | AI Assistant |
 | 2025-10-10 | Enabled branch protection rulesets and added CODEOWNERS | AI Assistant |
+| 2026-01-04 | Fixed PowerShell 5.1 compatibility: remove non-ASCII from shipped .ps1 and avoid interactive git prompt | AI Assistant |
 
 ---
 
@@ -53,8 +54,9 @@ cursor-kooi-env-docs/
 │   ├── nodejs-express/
 │   └── python-flask/
 ├── template/                     # Template files for installer
-│   ├── project-environment.md
-│   ├── rules/environment-maintenance.mdc
+│   ├── rules/
+│   │   ├── project-environment.mdc
+│   │   └── environment-maintenance.mdc
 │   ├── check-env-docs.ps1 / .sh
 │   ├── validate-install.ps1 / .sh
 │   ├── quick-prompt.txt
@@ -220,7 +222,15 @@ Unexpected token ')' in expression or statement.
 Get-Content .\install.ps1 -Raw | Select-String "`r`n"  # Should match (CRLF)
 ```
 
-### 2. Local vs GitHub Installer Testing
+### 2. PowerShell 5.1 Encoding (Non-ASCII Can Break Downloaded Scripts)
+
+**Problem:** Windows PowerShell 5.1 can misinterpret downloaded `.ps1` files that contain **emoji / non-ASCII** characters (often served as UTF-8 without BOM). This can corrupt characters into `�` and trigger parser errors.
+
+**Solution:**
+- ✅ Keep shipped `.ps1` scripts **ASCII-only** (no emoji/checkmarks)
+- ✅ If you hit parser errors after download, re-run the installer with `--force` to refresh scripts
+
+### 3. Local vs GitHub Installer Testing
 
 **Local Testing:**
 - ❌ Running `.\install.ps1` locally may fail if line endings are mixed
@@ -241,7 +251,7 @@ git push origin main
 irm https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/main/install.ps1 | iex
 ```
 
-### 3. PowerShell Command Chaining
+### 4. PowerShell Command Chaining
 
 **Issue:** PowerShell's `&&` operator requires PowerShell 7+, but we support 5.1+
 
@@ -258,7 +268,7 @@ git add -A
 git commit -m "msg"
 ```
 
-### 4. Path Quoting
+### 5. Path Quoting
 
 **Windows paths with spaces:**
 ```powershell
@@ -508,4 +518,4 @@ Create a self-updating documentation system that keeps Cursor AI assistants info
 
 ---
 
-**End of Documentation** • Last Updated: 2025-10-08 • Next Review: 2025-10-15
+**End of Documentation** • Last Updated: 2026-01-04 • Next Review: 2026-01-11

--- a/.cursor/validate-install.ps1
+++ b/.cursor/validate-install.ps1
@@ -1,7 +1,12 @@
 # Validate Cursor Environment Docs Installation
 # Run this script to verify your installation is complete and correct
 
-Write-Host "`n🔍 Validating Cursor Environment Docs Installation...`n" -ForegroundColor Cyan
+Write-Host "`n[INFO] Validating Cursor Environment Docs Installation...`n" -ForegroundColor Cyan
+
+# Resolve paths relative to the script location so this works even when invoked from another directory.
+# This script lives in: <project>/.cursor/validate-install.ps1
+$cursorDir = $PSScriptRoot
+$projectRoot = Split-Path -Parent $cursorDir
 
 $errors = 0
 $warnings = 0
@@ -11,10 +16,10 @@ function Test-FileExists {
     param($path, $description)
     
     if (Test-Path $path) {
-        Write-Host "  ✓ $description" -ForegroundColor Green
+        Write-Host "  [OK] $description" -ForegroundColor Green
         return $true
     } else {
-        Write-Host "  ✗ $description - NOT FOUND" -ForegroundColor Red
+        Write-Host "  [ERR] $description - NOT FOUND" -ForegroundColor Red
         $script:errors++
         return $false
     }
@@ -25,34 +30,35 @@ function Test-OptionalFile {
     param($path, $description)
     
     if (Test-Path $path) {
-        Write-Host "  ✓ $description" -ForegroundColor Green
+        Write-Host "  [OK] $description" -ForegroundColor Green
     } else {
-        Write-Host "  ⚠ $description - Not found (optional)" -ForegroundColor Yellow
+        Write-Host "  [WARN] $description - Not found (optional)" -ForegroundColor Yellow
         $script:warnings++
     }
 }
 
 # 1. Check required files
 Write-Host "[Required Files]" -ForegroundColor Cyan
-Test-FileExists ".cursor/project-environment.md" "project-environment.md"
-Test-FileExists ".cursor/rules/environment-maintenance.mdc" "environment-maintenance.mdc"
+Test-FileExists (Join-Path $cursorDir "rules\\project-environment.mdc") "project-environment.mdc"
+Test-FileExists (Join-Path $cursorDir "rules\\environment-maintenance.mdc") "environment-maintenance.mdc"
 
 # 2. Check optional but recommended files
 Write-Host "`n[Recommended Files]" -ForegroundColor Cyan
-Test-OptionalFile ".cursor/quick-prompt.txt" "quick-prompt.txt"
-Test-OptionalFile ".cursor/check-env-docs.ps1" "check-env-docs.ps1"
-Test-OptionalFile ".cursor/check-env-docs.sh" "check-env-docs.sh"
-Test-OptionalFile ".cursor/README.md" "README.md"
+Test-OptionalFile (Join-Path $cursorDir "quick-prompt.txt") "quick-prompt.txt"
+Test-OptionalFile (Join-Path $cursorDir "check-env-docs.ps1") "check-env-docs.ps1"
+Test-OptionalFile (Join-Path $cursorDir "check-env-docs.sh") "check-env-docs.sh"
+Test-OptionalFile (Join-Path $cursorDir "README.md") "README.md"
 
-# 3. Validate project-environment.md format
+# 3. Validate project-environment.mdc format
 Write-Host "`n[Document Format]" -ForegroundColor Cyan
 
-if (Test-Path ".cursor/project-environment.md") {
-    $content = Get-Content ".cursor/project-environment.md" -Raw
+$envDocPath = Join-Path $cursorDir "rules\\project-environment.mdc"
+if (Test-Path $envDocPath) {
+    $content = Get-Content $envDocPath -Raw
     
     # Check for Last Updated
     if ($content -match '>\s*\*\*Last Updated:\*\*\s*\d{4}-\d{2}-\d{2}') {
-        Write-Host "  ✓ 'Last Updated' date format correct" -ForegroundColor Green
+        Write-Host "  [OK] 'Last Updated' date format correct" -ForegroundColor Green
         
         # Extract and check date
         if ($content -match '>\s*\*\*Last Updated:\*\*\s*(\d{4}-\d{2}-\d{2})') {
@@ -62,42 +68,42 @@ if (Test-Path ".cursor/project-environment.md") {
             $daysSince = ($today - $lastUpdated).Days
             
             if ($daysSince -le 7) {
-                Write-Host "  ✓ Documentation is current ($daysSince days old)" -ForegroundColor Green
+                Write-Host "  [OK] Documentation is current ($daysSince days old)" -ForegroundColor Green
             } elseif ($daysSince -le 14) {
-                Write-Host "  ⚠ Documentation needs review ($daysSince days old)" -ForegroundColor Yellow
+                Write-Host "  [WARN] Documentation needs review ($daysSince days old)" -ForegroundColor Yellow
                 $warnings++
             } else {
-                Write-Host "  ⚠ Documentation is stale ($daysSince days old)" -ForegroundColor Yellow
+                Write-Host "  [WARN] Documentation is stale ($daysSince days old)" -ForegroundColor Yellow
                 $warnings++
             }
         }
     } else {
-        Write-Host "  ✗ 'Last Updated' date missing or incorrect format" -ForegroundColor Red
+        Write-Host "  [ERR] 'Last Updated' date missing or incorrect format" -ForegroundColor Red
         Write-Host "    Expected: > **Last Updated:** YYYY-MM-DD" -ForegroundColor Yellow
         $errors++
     }
     
     # Check for Next Review
     if ($content -match '>\s*\*\*Next Review:\*\*\s*\d{4}-\d{2}-\d{2}') {
-        Write-Host "  ✓ 'Next Review' date present" -ForegroundColor Green
+        Write-Host "  [OK] 'Next Review' date present" -ForegroundColor Green
     } else {
-        Write-Host "  ⚠ 'Next Review' date missing" -ForegroundColor Yellow
+        Write-Host "  [WARN] 'Next Review' date missing" -ForegroundColor Yellow
         $warnings++
     }
     
     # Check for Maintenance Log
     if ($content -match 'Maintenance Log') {
-        Write-Host "  ✓ Maintenance Log section present" -ForegroundColor Green
+        Write-Host "  [OK] Maintenance Log section present" -ForegroundColor Green
     } else {
-        Write-Host "  ⚠ Maintenance Log section missing" -ForegroundColor Yellow
+        Write-Host "  [WARN] Maintenance Log section missing" -ForegroundColor Yellow
         $warnings++
     }
     
     # Check for AI Instructions
     if ($content -match 'AI Assistant Instructions') {
-        Write-Host "  ✓ AI Assistant Instructions present" -ForegroundColor Green
+        Write-Host "  [OK] AI Assistant Instructions present" -ForegroundColor Green
     } else {
-        Write-Host "  ⚠ AI Assistant Instructions missing" -ForegroundColor Yellow
+        Write-Host "  [WARN] AI Assistant Instructions missing" -ForegroundColor Yellow
         $warnings++
     }
 }
@@ -105,36 +111,64 @@ if (Test-Path ".cursor/project-environment.md") {
 # 4. Check git integration
 Write-Host "`n[Git Integration]" -ForegroundColor Cyan
 
-if (Test-Path ".git") {
-    Write-Host "  ✓ Git repository detected" -ForegroundColor Green
-    
-    # Check if .cursor/ is tracked
-    $gitStatus = git status --porcelain .cursor/ 2>$null
-    if ($LASTEXITCODE -eq 0) {
-        Write-Host "  ✓ .cursor/ directory is in git repository" -ForegroundColor Green
+$gitCmd = Get-Command git -ErrorAction SilentlyContinue
+if (-not $gitCmd) {
+    Write-Host "  [WARN] Git is not installed or not on PATH (git command not found)" -ForegroundColor Yellow
+    Write-Host "         This system still works locally, but shared docs are best committed to a repo." -ForegroundColor Yellow
+    $warnings++
+} else {
+    $isInsideWorkTree = $false
+    try {
+        $inside = (git rev-parse --is-inside-work-tree 2>$null)
+        if ($LASTEXITCODE -eq 0 -and $inside -eq "true") { $isInsideWorkTree = $true }
+    } catch {
+        $isInsideWorkTree = $false
+    }
+
+    if ($isInsideWorkTree) {
+        Write-Host "  [OK] Git repository detected" -ForegroundColor Green
+
+        $tracked = @(git ls-files -- ".cursor" 2>$null)
+        if ($tracked.Count -gt 0) {
+            Write-Host "  [OK] .cursor/ has tracked file(s) in git" -ForegroundColor Green
+        } else {
+            $ignored = $false
+            try {
+                git check-ignore -q ".cursor" 2>$null
+                if ($LASTEXITCODE -eq 0) { $ignored = $true }
+            } catch {
+                $ignored = $false
+            }
+
+            if ($ignored) {
+                Write-Host "  [WARN] .cursor/ appears to be ignored by git" -ForegroundColor Yellow
+                Write-Host "         Remove it from .gitignore so the rules/docs can be shared." -ForegroundColor Yellow
+                $warnings++
+            } else {
+                Write-Host "  [WARN] .cursor/ is not tracked by git yet" -ForegroundColor Yellow
+                Write-Host "         Run: git add .cursor/" -ForegroundColor Yellow
+                $warnings++
+            }
+        }
     } else {
-        Write-Host "  ⚠ .cursor/ directory not tracked by git" -ForegroundColor Yellow
-        Write-Host "    Run: git add .cursor/" -ForegroundColor Yellow
+        Write-Host "  [WARN] Not a git repository" -ForegroundColor Yellow
+        Write-Host "         This system works locally; git is recommended for team sharing." -ForegroundColor Yellow
         $warnings++
     }
-} else {
-    Write-Host "  ⚠ Not a git repository" -ForegroundColor Yellow
-    Write-Host "    This system works best with git version control" -ForegroundColor Yellow
-    $warnings++
 }
 
 # 5. Check script executability
 Write-Host "`n[Scripts]" -ForegroundColor Cyan
 
-if (Test-Path ".cursor/check-env-docs.ps1") {
-    Write-Host "  ✓ PowerShell check script present" -ForegroundColor Green
+if (Test-Path (Join-Path $cursorDir "check-env-docs.ps1")) {
+    Write-Host "  [OK] PowerShell check script present" -ForegroundColor Green
     
     # Try to run it
     try {
-        $checkOutput = & .\.cursor\check-env-docs.ps1 2>&1
-        Write-Host "  ✓ PowerShell check script is executable" -ForegroundColor Green
+        $checkOutput = & (Join-Path $cursorDir "check-env-docs.ps1") 2>&1
+        Write-Host "  [OK] PowerShell check script is executable" -ForegroundColor Green
     } catch {
-        Write-Host "  ⚠ PowerShell check script may have execution issues" -ForegroundColor Yellow
+        Write-Host "  [WARN] PowerShell check script may have execution issues" -ForegroundColor Yellow
         $warnings++
     }
 }
@@ -145,20 +179,20 @@ Write-Host "Validation Summary" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 
 if ($errors -eq 0 -and $warnings -eq 0) {
-    Write-Host "✅ EXCELLENT! Installation is complete and correct." -ForegroundColor Green
+    Write-Host "[OK] EXCELLENT! Installation is complete and correct." -ForegroundColor Green
     Write-Host "`nYour environment documentation system is ready to use!" -ForegroundColor Green
 } elseif ($errors -eq 0) {
-    Write-Host "✅ GOOD! Installation is functional with $warnings warning(s)." -ForegroundColor Yellow
+    Write-Host "[OK] GOOD! Installation is functional with $warnings warning(s)." -ForegroundColor Yellow
     Write-Host "`nThe system will work, but consider addressing the warnings above." -ForegroundColor Yellow
 } else {
-    Write-Host "❌ ISSUES FOUND: $errors error(s), $warnings warning(s)" -ForegroundColor Red
+    Write-Host "[ERR] ISSUES FOUND: $errors error(s), $warnings warning(s)" -ForegroundColor Red
     Write-Host "`nPlease fix the errors above before using the system." -ForegroundColor Red
     Write-Host "See docs/TROUBLESHOOTING.md for help." -ForegroundColor Yellow
 }
 
-Write-Host "`n📚 Next Steps:" -ForegroundColor Cyan
+Write-Host "`n[Next Steps]" -ForegroundColor Cyan
 if ($errors -eq 0) {
-    Write-Host "  1. Commit .cursor/ to git: git add .cursor/ && git commit" -ForegroundColor White
+    Write-Host "  1. (Optional) Commit .cursor/ to git: git add .cursor/ ; git commit" -ForegroundColor White
     Write-Host "  2. Start using AI with your project" -ForegroundColor White
     Write-Host "  3. Check staleness anytime: .\.cursor\check-env-docs.ps1" -ForegroundColor White
 } else {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes yet._
+### 🐛 Bug Fixes
+- **PowerShell 5.1 compatibility**: Removed non-ASCII/emoji output from shipped `.ps1` scripts so they run reliably when downloaded from GitHub raw.
+- **Non-git folders supported**: Windows installer no longer prompts interactively when `.git` is missing; git is treated as optional and recommended for sharing/versioning.
+- **Validation improvements**: `validate-install.ps1` now:
+  - Works without git installed (warns instead of failing)
+  - Avoids PowerShell 7-only `&&` in printed guidance
+  - Better distinguishes: “git missing” vs “not a git repo” vs “.cursor not tracked/ignored”
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ curl -fsSL https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/main/i
 irm https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/main/install.ps1 | iex
 ```
 
-> **Security Note:** The installer downloads and runs scripts from GitHub. You can [review the installer script](https://github.com/u00dxk2/cursor-kooi-env-docs/blob/main/install.sh) before running. It only creates a `.cursor/` directory in your current project—no system-level changes, no admin/root privileges required.
+> **Compatibility Note:** Works in **Windows PowerShell 5.1+** and **PowerShell 7+**.
+
+> **Security Note:** The installer downloads and runs scripts from GitHub. You can review the installer scripts before running: [Windows installer](https://github.com/u00dxk2/cursor-kooi-env-docs/blob/main/install.ps1), [Unix/macOS installer](https://github.com/u00dxk2/cursor-kooi-env-docs/blob/main/install.sh). It only creates a `.cursor/` directory in your current project—no system-level changes, no admin/root privileges required.
 
 > **⚠️ Existing .cursor/ Setup:** The installer **preserves existing files** by default. If you have an existing `.cursor/` directory, only missing files will be added. To overwrite everything (clean reinstall), download the installer and run with `--force` flag:
 > ```bash
@@ -63,6 +65,8 @@ After installation:
    git commit -m "feat: Add environment documentation system"
    git push
    ```
+
+   If your folder is **not a git repo** (or you don't have git installed), you can skip this step. Git is recommended for team sharing/versioning, but not required for local use.
 
 **Important:** Commit the entire `.cursor/` directory! This is shared project documentation, not personal IDE settings. Your team needs these files.
 

--- a/docs/TEACHING-CURSOR-TO-REMEMBER.md
+++ b/docs/TEACHING-CURSOR-TO-REMEMBER.md
@@ -1,0 +1,104 @@
+# Teaching Cursor to Remember
+### Introducing Cursor Kooi Environment Docs
+
+**Go here if you want to get right to it:**
+[https://github.com/u00dxk2/cursor-kooi-env-docs](https://github.com/u00dxk2/cursor-kooi-env-docs)
+
+### The Problem: Context Amnesia
+Cursor is powerful, but every new chat starts with a blank slate. The agent doesn’t remember your shell, your OS’s quirks, the correct entry points to your stack, your localhost ports, or the "gotchas" you tripped over last week.
+
+That amnesia resets trust, wastes minutes, burns tokens, and breaks flow. **Cursor Kooi Environment Docs** fixes that by auto‑loading your project’s reality into every conversation, making the assistant behave like a teammate who’s already onboarded.
+
+### What It Is
+This is an open‑source, zero‑dependency documentation system that lives in your repo under `.cursor/rules/`. It is built on a specific architecture designed for long-term maintainability: **Separation of Concerns**.
+
+1.  **The Brain (Passive Context):** `project-environment.mdc`
+    This file is pure data. It holds your paths, commands, tech stack, and known issues. No instructions, just facts.
+2.  **The Guardian (Active Rule):** `environment-maintenance.mdc`
+    This file is pure logic. It runs silently in the background, monitoring "The Brain." If the documentation gets stale or files change, *this* rule prompts the AI to update the docs.
+
+Because these files use YAML frontmatter with `alwaysApply: true`, Cursor reads them automatically at the start of every conversation. No pasting. No pinning. No rituals. Just context that sticks.
+
+### What It Does
+*   **Auto‑ingests reality:** Shell, OS, paths, ports, and boot steps are injected into the context window immediately.
+*   **Captures "Gotchas":** When you trip on something non‑obvious, you write it down once. The AI reads it forever.
+*   **Self‑Healing:** The Active Rule watches your project. If `package.json` changes or the docs haven't been updated in 7 days, the AI proactively offers to refresh the environment file.
+*   **Validates Itself:** Simple PowerShell/Bash scripts verify that the docs are present, parseable, and current.
+
+The payoff: fewer wrong turns, more first‑try correctness, and the end of saying, "No, not like that; we’re on PowerShell."
+
+### Why I Built It
+I was tired of the Groundhog Day routine:
+
+1.  **Me:** "Install dependencies."
+2.  **Cursor:** Suggests `npm install && npm start`
+3.  **Me:** *Sighs.* "I'm on Windows PowerShell. It chokes on `&&`."
+4.  **Cursor:** "Apologies. Here is the corrected command..."
+5.  *New chat next week… repeat steps 1-4.*
+
+The assistant wasn’t failing; I was failing to give it a Single Source of Truth. I needed a repeatable, opinionated way to store environment reality where Cursor *always* looks—and a way to teach the assistant to keep that reality fresh.
+
+### How It Works
+No runtimes, no background services—just text and shell. The system is Markdown (`.mdc`) plus a couple of scripts.
+
+The installers are genuine one‑liners that handle the cross-platform nuances (like ensuring `CRLF` line endings for PowerShell and `LF` for Bash):
+
+**Windows (PowerShell):**
+```powershell
+irm https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/main/install.ps1 | iex
+```
+
+**macOS/Linux (Bash):**
+```bash
+curl -fsSL https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/main/install.sh | bash
+```
+
+**The Shape of the Install:**
+```text
+your-project/
+└── .cursor/
+    ├── rules/
+    │   ├── project-environment.mdc      # The Data (Context)
+    │   └── environment-maintenance.mdc  # The Logic (Rule)
+    ├── check-env-docs.ps1 / .sh         # Staleness checkers
+    ├── validate-install.ps1 / .sh       # Integrity validators
+    └── quick-prompt.txt                 # Setup prompt
+```
+
+### The "Environment-First" Workflow
+1.  **Install:** Run the one-liner.
+2.  **Generate:** Use the `quick-prompt.txt` to have Cursor write your initial `project-environment.mdc`.
+3.  **Commit:** Check `.cursor/` into git so your whole team shares the brain.
+4.  **Work:** Open a new chat. The doc is already in context. Give tasks as if the assistant just finished onboarding.
+5.  **Maintain:** When you change a library, the Active Rule will notice and ask: *"I see package.json changed. Should I update project-environment.mdc?"*
+
+### Before vs. After
+
+**Before:**
+> **You:** “Install dependencies.”
+> **Cursor:** `npm install && npm start`
+> **Terminal:** *Error: The token '&&' is not a valid statement separator in this version.*
+> **You:** *Fixes it manually.* Next week: Same mistake.
+
+**After (v1.1.3):**
+> **You:** “Install dependencies.”
+> **Cursor (Reads Context):** *User is on Windows 11 using PowerShell 7. Syntax requires `;`.*
+> **Cursor:** `npm install; npm start`
+> **Terminal:** *Success.*
+
+### Security & Practicality
+*   **Plain Text:** Everything lives in your repo. No black boxes.
+*   **Zero Elevation:** Installers run in user-space. No admin rights needed.
+*   **No Secrets:** The templates explicitly warn you not to store API keys in these files (use `.env` as usual).
+*   **Opt-In:** If you have sensitive internal paths, you can `.gitignore` the folder; it works just as well as a local-only tool.
+
+### Try It (Under 60 Seconds)
+Go to a project where you constantly have to correct the AI. Run the installer. Start a new chat. Ask it to do that thing it usually gets wrong.
+
+Watch it "just know."
+
+Then capture a fresh gotcha in the doc, and let tomorrow’s chat benefit from today’s pain. That’s the compounding effect of **Cursor Kooi Environment Docs**.
+
+[**Get it on GitHub**](https://github.com/u00dxk2/cursor-kooi-env-docs)
+
+

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -174,28 +174,38 @@ Unexpected token ')' in expression or statement.
 ```
 
 **Root Cause:**
-The PowerShell script may have Unix line endings (LF) instead of Windows line endings (CRLF), causing parsing errors.
+This can happen on **Windows PowerShell 5.1** when a downloaded `.ps1` file contains **non-ASCII characters** (emoji/checkmarks) and is served as **UTF-8 without BOM**. PowerShell 5.1 may interpret the file using the system ANSI codepage, corrupting characters into `�` and triggering parser errors.
+
+In older releases, this could also be caused by incorrect line endings (LF vs CRLF), but encoding/emoji was the most common culprit for "random" parser failures after downloading from GitHub.
 
 **Solutions:**
 
-**Option 1: Just skip it** (Recommended)
-- The validation script is a **troubleshooting tool**, not required for normal operation
-- If the installer completed successfully and files exist, you're good to go!
-- Validation is only useful if you suspect something went wrong
+**Option 1: Update to the latest scripts (recommended)**
+- Re-run installation with `--force` to refresh `.cursor/*.ps1` from the latest release (these scripts are now **ASCII-only** for PS5.1 compatibility).
 
-**Option 2: Fix line endings manually**
 ```powershell
-# Convert line endings
+irm https://raw.githubusercontent.com/u00dxk2/cursor-kooi-env-docs/main/install.ps1 -OutFile install.ps1
+.\install.ps1 --force
+```
+
+**Option 2: Fix encoding manually (if you can't update right now)**
+- This removes corrupted characters by re-saving the file as plain ASCII.
+
+```powershell
+$content = Get-Content .\.cursor\validate-install.ps1 -Raw
+# Re-save as ASCII to avoid PS5.1 encoding issues
+Set-Content .\.cursor\validate-install.ps1 -Value $content -Encoding Ascii
+```
+
+**Option 3: (Less common) Fix line endings manually**
+```powershell
 $content = Get-Content .\.cursor\validate-install.ps1 -Raw
 $content = $content -replace "`r?`n", "`r`n"
 Set-Content .\.cursor\validate-install.ps1 -Value $content -NoNewline
 ```
 
-**Option 3: Re-download after line ending fix**
-Wait for the next release (post-v1.0.0) which includes `.gitattributes` to enforce correct line endings.
-
 **Prevention:**
-This is fixed in versions after v1.0.0 with proper `.gitattributes` configuration.
+Current versions ship PowerShell scripts using **ASCII-only output** so they work reliably in both Windows PowerShell 5.1 and PowerShell 7+.
 
 ---
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,26 +1,22 @@
 # Cursor Environment Docs System - Installer (Windows)
 # https://github.com/u00dxk2/cursor-kooi-env-docs
-# Version: 1.2.0
-# Updated: 2025-11-19
+# Version: 1.2.1
+# Updated: 2026-01-04
 
 # Parse command line arguments
 $forceInstall = $args -contains "--force"
 
-Write-Host "`n🚀 Installing Cursor Environment Docs System...`n" -ForegroundColor Cyan
+Write-Host "`n[INFO] Installing Cursor Environment Docs System...`n" -ForegroundColor Cyan
 
-# Check if in a git repo (warning, not error)
+# Git is optional. We warn if it looks like you're not in a git repository root, but we do not block installation.
 if (-not (Test-Path ".git")) {
-    Write-Host "⚠️  Warning: Not in a git repository root" -ForegroundColor Yellow
-    Write-Host "This tool works best in the root of a git project."
-    $continue = Read-Host "Continue anyway? (y/n)"
-    if ($continue -ne "y") {
-        Write-Host "Installation cancelled."
-        exit 1
-    }
+    Write-Host "[WARN] Not in a git repository root (.git not found in current directory)" -ForegroundColor Yellow
+    Write-Host "       This system works best when committed to version control, but it can still be used locally." -ForegroundColor Yellow
+    Write-Host "       Tip: If you want git here later, run: git init" -ForegroundColor Yellow
 }
 
 # Create .cursor directory structure
-Write-Host "📁 Creating directory structure..." -ForegroundColor Cyan
+Write-Host "[INFO] Creating directory structure..." -ForegroundColor Cyan
 New-Item -ItemType Directory -Force -Path ".cursor\rules" | Out-Null
 
 # Base URL for downloading files
@@ -34,19 +30,19 @@ $failedDownloads = 0
 # Check if .cursor/ directory has existing files
 if ((Test-Path ".cursor") -and ((Get-ChildItem ".cursor" -Force -ErrorAction SilentlyContinue | Measure-Object).Count -gt 0)) {
     if (-not $forceInstall) {
-        Write-Host "⚠️  Existing .cursor\ setup detected" -ForegroundColor Yellow
-        Write-Host "Existing files will be preserved (use --force to overwrite)" -ForegroundColor Yellow
+        Write-Host "[WARN] Existing .cursor\ setup detected" -ForegroundColor Yellow
+        Write-Host "       Existing files will be preserved (use --force to overwrite)" -ForegroundColor Yellow
         Write-Host ""
     }
     else {
-        Write-Host "⚠️  Existing .cursor\ setup detected" -ForegroundColor Yellow
-        Write-Host "--force flag detected: will overwrite existing files" -ForegroundColor Yellow
+        Write-Host "[WARN] Existing .cursor\ setup detected" -ForegroundColor Yellow
+        Write-Host "       --force flag detected: will overwrite existing files" -ForegroundColor Yellow
         Write-Host ""
     }
 }
 
 # Download template files
-Write-Host "📥 Downloading template files..." -ForegroundColor Cyan
+Write-Host "[INFO] Downloading template files..." -ForegroundColor Cyan
 
 function Download-File {
     param($url, $dest)
@@ -54,7 +50,7 @@ function Download-File {
     
     # Check if file exists and we're not in force mode
     if ((Test-Path $dest) -and (-not $forceInstall)) {
-        Write-Host "  ⚠ $filename (exists - skipped)" -ForegroundColor Yellow
+        Write-Host "  [WARN] $filename (exists - skipped)" -ForegroundColor Yellow
         $script:skippedFiles += $filename
         return $true
     }
@@ -62,12 +58,12 @@ function Download-File {
     # Download the file
     try {
         Invoke-WebRequest -Uri $url -OutFile $dest -ErrorAction Stop
-        Write-Host "  ✓ $filename" -ForegroundColor Green
+        Write-Host "  [OK] $filename" -ForegroundColor Green
         $script:installedFiles += $filename
         return $true
     }
     catch {
-        Write-Host "  ✗ Failed to download $filename" -ForegroundColor Red
+        Write-Host "  [ERR] Failed to download $filename" -ForegroundColor Red
         return $false
     }
 }
@@ -80,32 +76,32 @@ if (!(Download-File "$baseUrl/validate-install.ps1" ".cursor\validate-install.ps
 
 # Check if any critical files failed
 if ($failedDownloads -gt 0) {
-    Write-Host "`n❌ Installation failed: $failedDownloads file(s) could not be downloaded" -ForegroundColor Red
+    Write-Host "`n[ERR] Installation failed: $failedDownloads file(s) could not be downloaded" -ForegroundColor Red
     Write-Host "Please check your internet connection and try again." -ForegroundColor Yellow
     exit 1
 }
 
-Write-Host "`n✅ Template files installed successfully!" -ForegroundColor Green
+Write-Host "`n[OK] Template files installed successfully!" -ForegroundColor Green
 Write-Host ""
 
 # Show summary
 if ($installedFiles.Count -gt 0 -or $skippedFiles.Count -gt 0) {
-    Write-Host "📊 Summary:" -ForegroundColor Cyan
+    Write-Host "[INFO] Summary:" -ForegroundColor Cyan
     if ($installedFiles.Count -gt 0) {
-        Write-Host "  ✓ Installed: $($installedFiles.Count) file(s)" -ForegroundColor Green
+        Write-Host "  [OK] Installed: $($installedFiles.Count) file(s)" -ForegroundColor Green
     }
     if ($skippedFiles.Count -gt 0) {
-        Write-Host "  ⚠ Skipped: $($skippedFiles.Count) existing file(s)" -ForegroundColor Yellow
+        Write-Host "  [WARN] Skipped: $($skippedFiles.Count) existing file(s)" -ForegroundColor Yellow
         Write-Host "    Tip: Use 'irm ... | iex' with --force to overwrite existing files" -ForegroundColor Yellow
         Write-Host "    Or download and run: .\install.ps1 --force" -ForegroundColor Yellow
     }
     Write-Host ""
 }
 
-Write-Host "⚠️  IMPORTANT: Installation requires one more critical step!" -ForegroundColor Red
+Write-Host "[WARN] IMPORTANT: Installation requires one more critical step!" -ForegroundColor Yellow
 Write-Host "You must create the project-environment.mdc file to complete setup.`n" -ForegroundColor Yellow
 
-Write-Host "📝 Next steps to complete installation:" -ForegroundColor Cyan
+Write-Host "[INFO] Next steps to complete installation:" -ForegroundColor Cyan
 Write-Host "1. View the quick prompt:"
 Write-Host "   Get-Content .cursor\quick-prompt.txt" -ForegroundColor Yellow
 Write-Host ""
@@ -114,17 +110,16 @@ Write-Host "   pwd   # Should show your project path" -ForegroundColor Yellow
 Write-Host ""
 Write-Host "3. Open this project with Cursor"
 Write-Host "4. Ask Cursor to create .cursor\rules\project-environment.mdc using the prompt"
-Write-Host "5. Commit documentation files to Git (see quick-prompt.txt for platform-specific commands):"
-Write-Host "   git add .cursor\rules\ .cursor\README.md .cursor\*.ps1" -ForegroundColor Yellow
-Write-Host "   git commit -m 'feat: Add environment documentation system'" -ForegroundColor Yellow
+Write-Host "5. (Optional) Commit documentation files to git (recommended for teams):"
+Write-Host "   git add .cursor\ ; git commit -m 'feat: Add environment documentation system'" -ForegroundColor Yellow
 Write-Host ""
-Write-Host "   💡 Note: .sh files don't exist on Windows-only projects - that's normal!" -ForegroundColor Cyan
-Write-Host "   ⚠️  IMPORTANT: Commit the .cursor\ documentation files." -ForegroundColor Yellow
+Write-Host "   Note: .sh files don't exist on Windows-only projects - that's normal." -ForegroundColor Cyan
+Write-Host "   IMPORTANT: Commit the .cursor\ documentation files (not personal IDE state)." -ForegroundColor Yellow
 Write-Host "   Do NOT add .cursor\ to .gitignore - it's shared team documentation!" -ForegroundColor Yellow
 Write-Host ""
-Write-Host "📊 Check documentation status anytime:" -ForegroundColor Cyan
+Write-Host "[INFO] Check documentation status anytime:" -ForegroundColor Cyan
 Write-Host "   .\.cursor\check-env-docs.ps1" -ForegroundColor Yellow
 Write-Host ""
-Write-Host "📚 Learn more: https://github.com/u00dxk2/cursor-kooi-env-docs" -ForegroundColor Cyan
+Write-Host "[INFO] Learn more: https://github.com/u00dxk2/cursor-kooi-env-docs" -ForegroundColor Cyan
 Write-Host ""
 

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Cursor Environment Docs System - Installer
 # https://github.com/u00dxk2/cursor-kooi-env-docs
-# Version: 1.1.3
+# Version: 1.1.4
 
 set -e
 
@@ -20,16 +20,12 @@ fi
 echo -e "${BLUE}🚀 Installing Cursor Environment Docs System...${NC}"
 echo ""
 
-# Check if in a git repo (warning, not error)
+# Git is optional. We warn if it looks like you're not in a git repository root, but we do not block installation.
+# (This script is often run via pipe-to-bash, where interactive prompts can hang.)
 if [ ! -d ".git" ]; then
-    echo -e "${YELLOW}⚠️  Warning: Not in a git repository root${NC}"
-    echo "This tool works best in the root of a git project."
-    read -p "Continue anyway? (y/n) " -n 1 -r
-    echo
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-        echo "Installation cancelled."
-        exit 1
-    fi
+    echo -e "${YELLOW}⚠️  Warning: Not in a git repository root (.git not found in current directory)${NC}"
+    echo -e "${YELLOW}    This system works best when committed to version control, but it can still be used locally.${NC}"
+    echo -e "${YELLOW}    Tip: If you want git here later, run: git init${NC}"
 fi
 
 # Create .cursor directory structure
@@ -126,7 +122,7 @@ echo -e "   ${YELLOW}cat .cursor/quick-prompt.txt${NC}"
 echo ""
 echo "2. Open this project with Cursor"
 echo "3. Ask Cursor to create .cursor/rules/project-environment.mdc using the prompt"
-echo "4. Commit ALL .cursor/ files to Git:"
+echo "4. (Optional) Commit .cursor/ to git (recommended for teams):"
 echo -e "   ${YELLOW}git add .cursor/${NC}"
 echo -e "   ${YELLOW}git commit -m 'feat: Add environment documentation system'${NC}"
 echo ""

--- a/template/check-env-docs.ps1
+++ b/template/check-env-docs.ps1
@@ -1,7 +1,8 @@
 # Check Environment Documentation Staleness
-# Run this script to see if .cursor/project-environment.md needs review
+# Run this script to see if .cursor/rules/project-environment.mdc needs review
 
-$envDocPath = ".cursor/rules/project-environment.mdc"
+$cursorDir = $PSScriptRoot
+$envDocPath = Join-Path $cursorDir "rules\\project-environment.mdc"
 $warningDays = 7
 $criticalDays = 14
 

--- a/template/check-env-docs.sh
+++ b/template/check-env-docs.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # Check Environment Documentation Staleness
-# Run this script to see if .cursor/project-environment.md needs review
+# Run this script to see if .cursor/rules/project-environment.mdc needs review
 
-ENV_DOC_PATH=".cursor/rules/project-environment.mdc"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENV_DOC_PATH="$SCRIPT_DIR/rules/project-environment.mdc"
 WARNING_DAYS=7
 CRITICAL_DAYS=14
 

--- a/template/validate-install.ps1
+++ b/template/validate-install.ps1
@@ -1,7 +1,12 @@
 # Validate Cursor Environment Docs Installation
 # Run this script to verify your installation is complete and correct
 
-Write-Host "`n🔍 Validating Cursor Environment Docs Installation...`n" -ForegroundColor Cyan
+Write-Host "`n[INFO] Validating Cursor Environment Docs Installation...`n" -ForegroundColor Cyan
+
+# Resolve paths relative to the script location so this works even when invoked from another directory.
+# This script lives in: <project>/.cursor/validate-install.ps1
+$cursorDir = $PSScriptRoot
+$projectRoot = Split-Path -Parent $cursorDir
 
 $errors = 0
 $warnings = 0
@@ -11,10 +16,10 @@ function Test-FileExists {
     param($path, $description)
     
     if (Test-Path $path) {
-        Write-Host "  ✓ $description" -ForegroundColor Green
+        Write-Host "  [OK] $description" -ForegroundColor Green
         return $true
     } else {
-        Write-Host "  ✗ $description - NOT FOUND" -ForegroundColor Red
+        Write-Host "  [ERR] $description - NOT FOUND" -ForegroundColor Red
         $script:errors++
         return $false
     }
@@ -25,34 +30,36 @@ function Test-OptionalFile {
     param($path, $description)
     
     if (Test-Path $path) {
-        Write-Host "  ✓ $description" -ForegroundColor Green
+        Write-Host "  [OK] $description" -ForegroundColor Green
     } else {
-        Write-Host "  ⚠ $description - Not found (optional)" -ForegroundColor Yellow
+        Write-Host "  [WARN] $description - Not found (optional)" -ForegroundColor Yellow
         $script:warnings++
     }
 }
 
 # 1. Check required files
 Write-Host "[Required Files]" -ForegroundColor Cyan
-Test-FileExists ".cursor/rules/project-environment.mdc" "project-environment.mdc"
-Test-FileExists ".cursor/rules/environment-maintenance.mdc" "environment-maintenance.mdc"
+Test-FileExists (Join-Path $cursorDir "rules\\project-environment.mdc") "project-environment.mdc"
+Test-FileExists (Join-Path $cursorDir "rules\\environment-maintenance.mdc") "environment-maintenance.mdc"
 
 # 2. Check optional but recommended files
 Write-Host "`n[Recommended Files]" -ForegroundColor Cyan
-Test-OptionalFile ".cursor/quick-prompt.txt" "quick-prompt.txt"
-Test-OptionalFile ".cursor/check-env-docs.ps1" "check-env-docs.ps1"
-Test-OptionalFile ".cursor/check-env-docs.sh" "check-env-docs.sh"
-Test-OptionalFile ".cursor/README.md" "README.md"
+Test-OptionalFile (Join-Path $cursorDir "quick-prompt.txt") "quick-prompt.txt"
+Test-OptionalFile (Join-Path $cursorDir "check-env-docs.ps1") "check-env-docs.ps1"
+Test-OptionalFile (Join-Path $cursorDir "check-env-docs.sh") "check-env-docs.sh"
+Test-OptionalFile (Join-Path $cursorDir "README.md") "README.md"
 
 # 3. Validate project-environment.mdc format
 Write-Host "`n[Document Format]" -ForegroundColor Cyan
 
 if (Test-Path ".cursor/rules/project-environment.mdc") {
-    $content = Get-Content ".cursor/rules/project-environment.mdc" -Raw
+$envDocPath = Join-Path $cursorDir "rules\\project-environment.mdc"
+if (Test-Path $envDocPath) {
+    $content = Get-Content $envDocPath -Raw
     
     # Check for Last Updated
     if ($content -match '>\s*\*\*Last Updated:\*\*\s*\d{4}-\d{2}-\d{2}') {
-        Write-Host "  ✓ 'Last Updated' date format correct" -ForegroundColor Green
+        Write-Host "  [OK] 'Last Updated' date format correct" -ForegroundColor Green
         
         # Extract and check date
         if ($content -match '>\s*\*\*Last Updated:\*\*\s*(\d{4}-\d{2}-\d{2})') {
@@ -62,34 +69,34 @@ if (Test-Path ".cursor/rules/project-environment.mdc") {
             $daysSince = ($today - $lastUpdated).Days
             
             if ($daysSince -le 7) {
-                Write-Host "  ✓ Documentation is current ($daysSince days old)" -ForegroundColor Green
+                Write-Host "  [OK] Documentation is current ($daysSince days old)" -ForegroundColor Green
             } elseif ($daysSince -le 14) {
-                Write-Host "  ⚠ Documentation needs review ($daysSince days old)" -ForegroundColor Yellow
+                Write-Host "  [WARN] Documentation needs review ($daysSince days old)" -ForegroundColor Yellow
                 $warnings++
             } else {
-                Write-Host "  ⚠ Documentation is stale ($daysSince days old)" -ForegroundColor Yellow
+                Write-Host "  [WARN] Documentation is stale ($daysSince days old)" -ForegroundColor Yellow
                 $warnings++
             }
         }
     } else {
-        Write-Host "  ✗ 'Last Updated' date missing or incorrect format" -ForegroundColor Red
+        Write-Host "  [ERR] 'Last Updated' date missing or incorrect format" -ForegroundColor Red
         Write-Host "    Expected: > **Last Updated:** YYYY-MM-DD" -ForegroundColor Yellow
         $errors++
     }
     
     # Check for Next Review
     if ($content -match '>\s*\*\*Next Review:\*\*\s*\d{4}-\d{2}-\d{2}') {
-        Write-Host "  ✓ 'Next Review' date present" -ForegroundColor Green
+        Write-Host "  [OK] 'Next Review' date present" -ForegroundColor Green
     } else {
-        Write-Host "  ⚠ 'Next Review' date missing" -ForegroundColor Yellow
+        Write-Host "  [WARN] 'Next Review' date missing" -ForegroundColor Yellow
         $warnings++
     }
     
     # Check for Maintenance Log
     if ($content -match 'Maintenance Log') {
-        Write-Host "  ✓ Maintenance Log section present" -ForegroundColor Green
+        Write-Host "  [OK] Maintenance Log section present" -ForegroundColor Green
     } else {
-        Write-Host "  ⚠ Maintenance Log section missing" -ForegroundColor Yellow
+        Write-Host "  [WARN] Maintenance Log section missing" -ForegroundColor Yellow
         $warnings++
     }
 }
@@ -97,36 +104,66 @@ if (Test-Path ".cursor/rules/project-environment.mdc") {
 # 4. Check git integration
 Write-Host "`n[Git Integration]" -ForegroundColor Cyan
 
-if (Test-Path ".git") {
-    Write-Host "  ✓ Git repository detected" -ForegroundColor Green
-    
-    # Check if .cursor/ is tracked
-    $gitStatus = git status --porcelain .cursor/ 2>$null
-    if ($LASTEXITCODE -eq 0) {
-        Write-Host "  ✓ .cursor/ directory is in git repository" -ForegroundColor Green
+$gitCmd = Get-Command git -ErrorAction SilentlyContinue
+if (-not $gitCmd) {
+    Write-Host "  [WARN] Git is not installed or not on PATH (git command not found)" -ForegroundColor Yellow
+    Write-Host "         This system still works locally, but shared docs are best committed to a repo." -ForegroundColor Yellow
+    $warnings++
+} else {
+    $isInsideWorkTree = $false
+    try {
+        $inside = (git rev-parse --is-inside-work-tree 2>$null)
+        if ($LASTEXITCODE -eq 0 -and $inside -eq "true") { $isInsideWorkTree = $true }
+    } catch {
+        $isInsideWorkTree = $false
+    }
+
+    if ($isInsideWorkTree) {
+        Write-Host "  [OK] Git repository detected" -ForegroundColor Green
+
+        # Check whether any .cursor files are tracked (not just whether git is functioning)
+        $tracked = @(git ls-files -- ".cursor" 2>$null)
+        if ($tracked.Count -gt 0) {
+            Write-Host "  [OK] .cursor/ has tracked file(s) in git" -ForegroundColor Green
+        } else {
+            # If .cursor exists but has no tracked files, it's either untracked or ignored
+            $ignored = $false
+            try {
+                git check-ignore -q ".cursor" 2>$null
+                if ($LASTEXITCODE -eq 0) { $ignored = $true }
+            } catch {
+                $ignored = $false
+            }
+
+            if ($ignored) {
+                Write-Host "  [WARN] .cursor/ appears to be ignored by git" -ForegroundColor Yellow
+                Write-Host "         Remove it from .gitignore so the rules/docs can be shared." -ForegroundColor Yellow
+                $warnings++
+            } else {
+                Write-Host "  [WARN] .cursor/ is not tracked by git yet" -ForegroundColor Yellow
+                Write-Host "         Run: git add .cursor/" -ForegroundColor Yellow
+                $warnings++
+            }
+        }
     } else {
-        Write-Host "  ⚠ .cursor/ directory not tracked by git" -ForegroundColor Yellow
-        Write-Host "    Run: git add .cursor/" -ForegroundColor Yellow
+        Write-Host "  [WARN] Not a git repository" -ForegroundColor Yellow
+        Write-Host "         This system works locally; git is recommended for team sharing." -ForegroundColor Yellow
         $warnings++
     }
-} else {
-    Write-Host "  ⚠ Not a git repository" -ForegroundColor Yellow
-    Write-Host "    This system works best with git version control" -ForegroundColor Yellow
-    $warnings++
 }
 
 # 5. Check script executability
 Write-Host "`n[Scripts]" -ForegroundColor Cyan
 
-if (Test-Path ".cursor/check-env-docs.ps1") {
-    Write-Host "  ✓ PowerShell check script present" -ForegroundColor Green
+if (Test-Path (Join-Path $cursorDir "check-env-docs.ps1")) {
+    Write-Host "  [OK] PowerShell check script present" -ForegroundColor Green
     
     # Try to run it
     try {
-        $checkOutput = & .\.cursor\check-env-docs.ps1 2>&1
-        Write-Host "  ✓ PowerShell check script is executable" -ForegroundColor Green
+        $checkOutput = & (Join-Path $cursorDir "check-env-docs.ps1") 2>&1
+        Write-Host "  [OK] PowerShell check script is executable" -ForegroundColor Green
     } catch {
-        Write-Host "  ⚠ PowerShell check script may have execution issues" -ForegroundColor Yellow
+        Write-Host "  [WARN] PowerShell check script may have execution issues" -ForegroundColor Yellow
         $warnings++
     }
 }
@@ -137,20 +174,20 @@ Write-Host "Validation Summary" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 
 if ($errors -eq 0 -and $warnings -eq 0) {
-    Write-Host "✅ EXCELLENT! Installation is complete and correct." -ForegroundColor Green
+    Write-Host "[OK] EXCELLENT! Installation is complete and correct." -ForegroundColor Green
     Write-Host "`nYour environment documentation system is ready to use!" -ForegroundColor Green
 } elseif ($errors -eq 0) {
-    Write-Host "✅ GOOD! Installation is functional with $warnings warning(s)." -ForegroundColor Yellow
+    Write-Host "[OK] GOOD! Installation is functional with $warnings warning(s)." -ForegroundColor Yellow
     Write-Host "`nThe system will work, but consider addressing the warnings above." -ForegroundColor Yellow
 } else {
-    Write-Host "❌ ISSUES FOUND: $errors error(s), $warnings warning(s)" -ForegroundColor Red
+    Write-Host "[ERR] ISSUES FOUND: $errors error(s), $warnings warning(s)" -ForegroundColor Red
     Write-Host "`nPlease fix the errors above before using the system." -ForegroundColor Red
     Write-Host "See docs/TROUBLESHOOTING.md for help." -ForegroundColor Yellow
 }
 
-Write-Host "`n📚 Next Steps:" -ForegroundColor Cyan
+Write-Host "`n[Next Steps]" -ForegroundColor Cyan
 if ($errors -eq 0) {
-    Write-Host "  1. Commit .cursor/ to git: git add .cursor/ && git commit" -ForegroundColor White
+    Write-Host "  1. (Optional) Commit .cursor/ to git: git add .cursor/ ; git commit" -ForegroundColor White
     Write-Host "  2. Start using AI with your project" -ForegroundColor White
     Write-Host "  3. Check staleness anytime: .\.cursor\check-env-docs.ps1" -ForegroundColor White
 } else {

--- a/template/validate-install.sh
+++ b/template/validate-install.sh
@@ -4,6 +4,12 @@
 
 set -e
 
+# Resolve paths relative to the script location so this works even when invoked from another directory.
+# This script lives in: <project>/.cursor/validate-install.sh
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CURSOR_DIR="$SCRIPT_DIR"
+PROJECT_ROOT="$(cd "$CURSOR_DIR/.." && pwd)"
+
 BLUE='\033[0;34m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -46,21 +52,22 @@ check_optional_file() {
 
 # 1. Check required files
 echo -e "${CYAN}[Required Files]${NC}"
-check_file_exists ".cursor/rules/project-environment.mdc" "project-environment.mdc"
-check_file_exists ".cursor/rules/environment-maintenance.mdc" "environment-maintenance.mdc"
+check_file_exists "$CURSOR_DIR/rules/project-environment.mdc" "project-environment.mdc"
+check_file_exists "$CURSOR_DIR/rules/environment-maintenance.mdc" "environment-maintenance.mdc"
 
 # 2. Check optional but recommended files
 echo -e "\n${CYAN}[Recommended Files]${NC}"
-check_optional_file ".cursor/quick-prompt.txt" "quick-prompt.txt"
-check_optional_file ".cursor/check-env-docs.ps1" "check-env-docs.ps1"
-check_optional_file ".cursor/check-env-docs.sh" "check-env-docs.sh"
-check_optional_file ".cursor/README.md" "README.md"
+check_optional_file "$CURSOR_DIR/quick-prompt.txt" "quick-prompt.txt"
+check_optional_file "$CURSOR_DIR/check-env-docs.ps1" "check-env-docs.ps1"
+check_optional_file "$CURSOR_DIR/check-env-docs.sh" "check-env-docs.sh"
+check_optional_file "$CURSOR_DIR/README.md" "README.md"
 
 # 3. Validate project-environment.mdc format
 echo -e "\n${CYAN}[Document Format]${NC}"
 
 if [ -f ".cursor/rules/project-environment.mdc" ]; then
-    content=$(cat .cursor/rules/project-environment.mdc)
+if [ -f "$CURSOR_DIR/rules/project-environment.mdc" ]; then
+    content=$(cat "$CURSOR_DIR/rules/project-environment.mdc")
     
     # Check for Last Updated (using grep -E for cross-platform compatibility)
     if echo "$content" | grep -qE 'Last Updated:.*[0-9]{4}-[0-9]{2}-[0-9]{2}'; then
@@ -121,11 +128,11 @@ fi
 # 4. Check git integration
 echo -e "\n${CYAN}[Git Integration]${NC}"
 
-if [ -d ".git" ]; then
+if [ -d "$PROJECT_ROOT/.git" ]; then
     echo -e "  ${GREEN}✓${NC} Git repository detected"
     
     # Check if .cursor/ is tracked
-    if git ls-files .cursor/ >/dev/null 2>&1 && [ -n "$(git ls-files .cursor/)" ]; then
+    if git -C "$PROJECT_ROOT" ls-files .cursor/ >/dev/null 2>&1 && [ -n "$(git -C "$PROJECT_ROOT" ls-files .cursor/)" ]; then
         echo -e "  ${GREEN}✓${NC} .cursor/ directory is in git repository"
     else
         echo -e "  ${YELLOW}⚠${NC} .cursor/ directory not tracked by git"


### PR DESCRIPTION
- Make Windows installer ASCII-only and non-interactive in non-git folders

- Make validate/check scripts work from any working directory via script-root paths

- Make bash installer non-interactive in non-git folders

- Update docs and changelog